### PR TITLE
add missing file on Spanish Translation, enable it by default

### DIFF
--- a/src/main/java/downfall/downfallMod.java
+++ b/src/main/java/downfall/downfallMod.java
@@ -246,13 +246,15 @@ public class downfallMod implements OnPlayerDamagedSubscriber, OnStartBattleSubs
     public static Settings.GameLanguage[] SupportedLanguages = {
             // Insert other languages here
             // DONT FORGET TO TOGGLE AT reskinContent.getLanguageString() TOO
-            Settings.GameLanguage.ENG, Settings.GameLanguage.ZHS,
-             Settings.GameLanguage.JPN,
+            Settings.GameLanguage.ENG,
+            Settings.GameLanguage.ZHS,
+            Settings.GameLanguage.JPN,
             Settings.GameLanguage.KOR,
-       //     Settings.GameLanguage.FRA,
-//            Settings.GameLanguage.ZHT,
-      //      Settings.GameLanguage.RUS,
-        //    Settings.GameLanguage.PTB
+            Settings.GameLanguage.SPA,
+            // Settings.GameLanguage.FRA,
+            // Settings.GameLanguage.ZHT,
+            // Settings.GameLanguage.RUS,
+            // Settings.GameLanguage.PTB
     };
 
     public static ReplaceData[] wordReplacements;

--- a/src/main/resources/hermitResources/localization/spa/CharacterStrings.json
+++ b/src/main/resources/hermitResources/localization/spa/CharacterStrings.json
@@ -1,0 +1,15 @@
+{
+  "hermit:hermit": {
+    "NAMES": [
+      "El Ermitaño",
+      "el Ermitaño"
+    ],
+    "TEXT": [
+      "Pistolero no muerto solitario de un lugar lejano. NL Perseguido por el espectro ineludible del pasado.",
+      "NL Alcanzas tu funda...",
+      "Navegando por una calle sin iluminar, te encuentras con varias figuras encapuchadas en medio de algún oscuro ritual. Al acercarte, se vuelven hacia ti en una aterradora sincronía. El más alto entre ellos muestra sus colmillos y extiende una mano larga y pálida hacia ti. NL ~«Únete~ ~a~ ~nosotros,~ ~vacío,~ ~y~ ~siente~ ~el~ ~calor~ ~del~ ~Spire.»~",
+      "#y~DESESPERACIÓN.~  NL NL El último adversario se hunde en el suelo, agarrando una herida humeante. Sus cuerpos apenas tienen tiempo de enfriarse antes de que comiences a saquear los restos. NL NL #bTelas. #rPlacas. #yOro. NL NL Las nubes se arremolinan alto por encima, un mal presagio. Has permanecido demasiado tiempo en un lugar. Pronto vendrán por ti. NL NL Nuevamente tienes que huir, #rpero #ra #rdónde?",
+      "Siguiente"
+    ]
+  }
+}


### PR DESCRIPTION
Added translation for the Hermit and enabled the Spanish Translation provided by @Gultard by default.

I did't checked it completely, the cards and Bosses translations look good.

I have builded & tested it locally and din't encounter any error or crash.

![646570_109](https://github.com/user-attachments/assets/c7a94de0-77c6-4439-88cb-861806b6b080)
![646570_110](https://github.com/user-attachments/assets/91e9433f-6e34-4187-9a98-58a62231aeec)
![646570_111](https://github.com/user-attachments/assets/e8edd1ee-453b-4742-83b7-b8f641dd77d3)
![646570_112](https://github.com/user-attachments/assets/97bb208a-3a8c-4084-9f41-74620788b508)
![646570_115](https://github.com/user-attachments/assets/fff18de3-7328-4fcb-ae33-6c8ded73ba99)
![646570_116](https://github.com/user-attachments/assets/febd5618-6dea-40e2-ba56-d9b4f38d1d10)
![646570_117](https://github.com/user-attachments/assets/1275285d-7162-4553-ba84-ea01216c5746)